### PR TITLE
Fix Typo in File Path in 7.create-tables.ipynb

### DIFF
--- a/benchmark/7.create-tables.ipynb
+++ b/benchmark/7.create-tables.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "replicability_pvalue = pd.read_csv(\"output/replicability_pvalue.csv\")\n",
     "\n",
-    "replicability_fp = pd.read_csv(\"output/cellprofiler_replicability_fp.csv\")"
+    "replicability_fp = pd.read_csv(\"output/cellprofiler_replicability_fr.csv\")"
    ]
   },
   {


### PR DESCRIPTION
#### Description:
This PR addresses a typo in the file path specified in 7.create-tables.ipynb

- **Current Path:** `output/cellprofiler_replicability_fp.csv`
- **Correct Path:** `output/cellprofiler_replicability_fr.csv`

#### Changes Made:
- Updated the incorrect file path in 7.create-tables.ipynb to reflect the correct file name.